### PR TITLE
Redmi小爱L07A音箱

### DIFF
--- a/xiaogpt/config.py
+++ b/xiaogpt/config.py
@@ -23,6 +23,7 @@ HARDWARE_COMMAND_DICT = {
     "X08E": ("7-3", "5-4"),
     "LX05A": ("5-1", "5-5"),  # 小爱红外版
     "LX5A": ("5-1", "5-5"),  # 小爱红外版
+    "L07A": ("5-1", "5-5"),  # Redmi小爱音箱Play(l7a)
     # add more here
 }
 DEFAULT_COMMAND = ("5-1", "5-5")


### PR DESCRIPTION
这个[issue](https://github.com/yihong0618/xiaogpt/issues/123) ，在各位大佬的提醒下，xiaogpt/config.py 文件 加了1行代码.   
`  "L07A": ("5-1", "5-5"),  # Redmi小爱音箱Play(l7a) 
`
红米小爱L07A音箱跑起来了。
使用方法不变，执行时 加上 硬件  --hardware L07A 即可
如： python3.9 xiaogpt.py    --mute_xiaoai --use_gpt3 --hardware L07A