### PR TITLE
依赖库更新，原有依赖已无匹配包

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,11 @@ aiosignal==1.3.1
 anyio==3.6.2
 async-timeout==4.0.2
 attrs==22.2.0
-BingImageCreator==0.1.3
+BingImageCreator==0.1.4
 certifi==2022.12.7
 charset-normalizer==3.1.0
-edge-tts==6.1.3
-EdgeGPT==0.1.26
+edge-tts==6.1.5
+EdgeGPT==0.3.5
 frozenlist==1.3.3
 h11==0.14.0
 httpcore==0.16.3
@@ -20,7 +20,7 @@ markdown-it-py==2.2.0
 mdurl==0.1.2
 miservice-fork==2.1.1
 multidict==6.0.4
-openai==0.27.2
+openai==0.27.6
 prompt-toolkit==3.0.38
 pygments==2.14.0
 regex==2022.10.31


### PR DESCRIPTION
ERROR: Could not find a version that satisfies the requirement EdgeGPT==0.1.26 (from versions: none)
ERROR: No matching distribution found for EdgeGPT==0.1.26