### PR TITLE
Refactor LangChain_Bot

### DIFF
--- a/xiaogpt/bot/langchain_bot.py
+++ b/xiaogpt/bot/langchain_bot.py
@@ -17,19 +17,30 @@ class LangChainBot(BaseBot):
         self,
         openai_key: str,
         serpapi_api_key: str,
+        proxy: str | None = None,
+        api_base: str | None = None,
     ) -> None:
         # Set environment indicators
         os.environ["OPENAI_API_KEY"] = openai_key
         os.environ["SERPAPI_API_KEY"] = serpapi_api_key
-        # todo，Plan to implement within langchain
+        if api_base:
+            os.environ["OPENAI_API_BASE"] = api_base
+        if proxy:
+            os.environ["OPENAI_PROXY"] = proxy
+        # Todo，Plan to implement within langchain
         self.history = []
 
     @classmethod
     def from_config(cls, config):
-        return cls(openai_key=config.openai_key, serpapi_api_key=config.serpapi_api_key)
+        return cls(
+            openai_key=config.openai_key,
+            serpapi_api_key=config.serpapi_api_key,
+            proxy=config.proxy,
+            api_base=config.api_base,
+        )
 
     async def ask(self, query, **options):
-        # todo，Currently only supports stream
+        # Todo，Currently only supports stream
         raise Exception(
             "The bot does not support it. Please use 'ask_stream，add： --stream'"
         )


### PR DESCRIPTION
Add api_base, proxy proxy settings

Usage：
- plan 1： --proxy http://175.100.90.184:8080  或 在config.proxy配置
- plan 2： --api_base http://127.0.0.1:8000/proxy-sse/v1 或 在config.api_base配置，推荐服务 [chatgpt-proxy](https://github.com/imyuanx/chatgpt-proxy)

Test：
<img width="1624" alt="image" src="https://github.com/yihong0618/xiaogpt/assets/21094836/71df5979-a184-4246-ac91-bfdab65f906c">

注：使用Proxy方式，受代理方影响，回答可能会慢